### PR TITLE
IWDG_Enable() bug

### DIFF
--- a/EVT/EXAM/SRC/Peripheral/src/ch32v00x_iwdg.c
+++ b/EVT/EXAM/SRC/Peripheral/src/ch32v00x_iwdg.c
@@ -92,7 +92,7 @@ void IWDG_ReloadCounter(void)
 void IWDG_Enable(void)
 {
     IWDG->CTLR = CTLR_KEY_Enable;
-    while ((RCC->RSTSCKR)|(0x2)!= SET);
+    while ((RCC->RSTSCKR)& RCC_LSIRDY != RCC_LSIRDY);
 }
 
 /*********************************************************************

--- a/EVT/EXAM/SRC/Peripheral/src/ch32v00x_iwdg.c
+++ b/EVT/EXAM/SRC/Peripheral/src/ch32v00x_iwdg.c
@@ -92,7 +92,7 @@ void IWDG_ReloadCounter(void)
 void IWDG_Enable(void)
 {
     IWDG->CTLR = CTLR_KEY_Enable;
-    while ((RCC->RSTSCKR)& RCC_LSIRDY != RCC_LSIRDY);
+    while ((RCC->RSTSCKR & RCC_LSIRDY) != RCC_LSIRDY);
 }
 
 /*********************************************************************


### PR DESCRIPTION
IWDG_Enable in ch32v00x_iwdg.c of the peripheral library has a bug while checking if the bit LSYRDY of the RSTSCKR register is set by waiting endlessly for it to be set with a condition impossible to meet:

`while ((RCC->RSTSCKR)|(0x2)!= SET);`

The correct way should be:

`while ((RCC->RSTSCKR & RCC_LSIRDY)!= RCC_LSIRDY);`    