### PR TITLE
Relax licensing terms and add explicit license for header files

### DIFF
--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/ch32f10x_conf.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/ch32f10x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_CONF_H
 #define __CH32F10x_CONF_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/ch32f10x_it.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/ch32f10x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_IT_H
 #define __CH32F10x_IT_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/flash_prg_algorithm.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/flash_prg_algorithm.h
@@ -6,8 +6,6 @@
  * Description        : single line debug interface for
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __FLASH_PRG_ALGORITHM_H
 #define __FLASH_PRG_ALGORITHM_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/flashop.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/flashop.h
@@ -6,8 +6,6 @@
  * Description        : single line debug interface for
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __FLASHOP_H
 #define __FLASHOP_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/singleline.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/components/singleline.h
@@ -6,8 +6,6 @@
  * Description        : single line debug interface for
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __SINGLELINE_H
 #define __SINGLELINE_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/system_ch32f10x.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/CH32V003_1Line/CH32V003_1Line/system_ch32f10x.h
@@ -6,8 +6,6 @@
  * Description        : CMSIS Cortex-M3 Device Peripheral Access Layer System Header File. 
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32F10x_H
 #define __SYSTEM_CH32F10x_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/Debug/debug.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/Debug/debug.h
@@ -7,8 +7,6 @@
  *                      Printf , Delay and Bit-Banding functions.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __DEBUG_H
 #define __DEBUG_H 	

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/Startup/startup_ch32f10x.s
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/Startup/startup_ch32f10x.s
@@ -6,8 +6,6 @@
 ;* Description        : CH32F10x vector table for MDK-ARM toolchain.
 ;*********************************************************************************
 ;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-;* Attention: This software (modified or not) and binary are used for 
-;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 ;*******************************************************************************/
 
 ;/*******************************************************************************

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x.h
@@ -6,8 +6,6 @@
  * Description        : CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/  
 #ifndef __CH32F10x_H
 #define __CH32F10x_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_adc.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_adc.h
@@ -7,8 +7,6 @@
  *                      ADC firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_ADC_H
 #define __CH32F10x_ADC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_bkp.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_bkp.h
@@ -7,8 +7,6 @@
  *                      BKP firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_BKP_H
 #define __CH32F10x_BKP_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_can.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_can.h
@@ -7,8 +7,6 @@
  *                      CAN firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_CAN_H
 #define __CH32F10x_CAN_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_crc.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_crc.h
@@ -7,8 +7,6 @@
  *                      CRC firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_CRC_H
 #define __CH32F10x_CRC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dac.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dac.h
@@ -7,8 +7,6 @@
  *                      DAC firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_DAC_H
 #define __CH32F10x_DAC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dbgmcu.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dbgmcu.h
@@ -7,8 +7,6 @@
  *                      DBGMCU firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_DBGMCU_H
 #define __CH32F10x_DBGMCU_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dma.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_dma.h
@@ -7,8 +7,6 @@
  *                      DMA firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/ 
 #ifndef __CH32F10x_DMA_H
 #define __CH32F10x_DMA_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_exti.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_exti.h
@@ -7,8 +7,6 @@
  *                      EXTI firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_EXTI_H
 #define __CH32F10x_EXTI_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_flash.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_flash.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_FLASH_H
 #define __CH32F10x_FLASH_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_gpio.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_gpio.h
@@ -7,8 +7,6 @@
  *                      GPIO firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_GPIO_H
 #define __CH32F10x_GPIO_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_i2c.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_i2c.h
@@ -7,8 +7,6 @@
  *                      I2C firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_I2C_H
 #define __CH32F10x_I2C_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_iwdg.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_iwdg.h
@@ -7,8 +7,6 @@
  *                      IWDG firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_IWDG_H
 #define __CH32F10x_IWDG_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_misc.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_misc.h
@@ -7,8 +7,6 @@
  *                      miscellaneous firmware library functions (add-on to CMSIS functions).
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/  
 #ifndef __CH32F10X_MISC_H
 #define __CH32F10X_MISC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_pwr.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_pwr.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_PWR_H
 #define __CH32F10x_PWR_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_rcc.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_rcc.h
@@ -6,8 +6,6 @@
  * Description        : This file provides all the RCC firmware functions.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_RCC_H
 #define __CH32F10x_RCC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_rtc.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_rtc.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_RTC_H
 #define __CH32F10x_RTC_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_spi.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_spi.h
@@ -7,8 +7,6 @@
  *                      SPI firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_SPI_H
 #define __CH32F10x_SPI_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_tim.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_tim.h
@@ -7,8 +7,6 @@
  *                      TIM firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_TIM_H
 #define __CH32F10x_TIM_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usart.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usart.h
@@ -7,8 +7,6 @@
  *                      USART firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_USART_H
 #define __CH32F10x_USART_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usb.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usb.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_USB_H
 #define __CH32F10x_USB_H

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usb_host.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_usb_host.h
@@ -6,8 +6,6 @@
  * Description        : This file provides all the USB firmware functions.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_USBHOST_H__
 #define __CH32F10x_USBHOST_H__

--- a/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_wwdg.h
+++ b/CH32V003_1Line_Base_on_CH32F103/CH32V003_1Line_SDIO_Program_Base_on_CH32F103/CH32V003_1Line/SRC/StdPeriphDriver/inc/ch32f10x_wwdg.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32F10x_WWDG_H
 #define __CH32F10x_WWDG_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Core/core_riscv.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Core/core_riscv.h
@@ -6,8 +6,6 @@
  * Description        : RISC-V Core Peripheral Access Layer Header File
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CORE_RISCV_H__
 #define __CORE_RISCV_H__

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Debug/debug.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Debug/debug.h
@@ -7,8 +7,6 @@
  *                      Printf , Delay functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __DEBUG_H
 #define __DEBUG_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer Header File.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_H
 #define __CH32V00x_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_adc.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_adc.h
@@ -7,8 +7,6 @@
  *                      ADC firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_ADC_H
 #define __CH32V00x_ADC_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_dbgmcu.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_dbgmcu.h
@@ -7,8 +7,6 @@
  *                      DBGMCU firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_DBGMCU_H
 #define __CH32V00x_DBGMCU_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_dma.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_dma.h
@@ -7,8 +7,6 @@
  *                      DMA firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_DMA_H
 #define __CH32V00x_DMA_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_exti.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_exti.h
@@ -7,8 +7,6 @@
  *                      EXTI firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_EXTI_H
 #define __CH32V00x_EXTI_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_flash.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_flash.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_FLASH_H
 #define __CH32V00x_FLASH_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_gpio.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_gpio.h
@@ -7,8 +7,6 @@
  *                      GPIO firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_GPIO_H
 #define __CH32V00x_GPIO_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_i2c.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_i2c.h
@@ -7,8 +7,6 @@
  *                      I2C firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_I2C_H
 #define __CH32V00x_I2C_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_iwdg.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_iwdg.h
@@ -7,8 +7,6 @@
  *                      IWDG firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_IWDG_H
 #define __CH32V00x_IWDG_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_misc.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_misc.h
@@ -7,8 +7,6 @@
  *                      miscellaneous firmware library functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/   
 #ifndef __CH32V00X_MISC_H
 #define __CH32V00X_MISC_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_opa.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_opa.h
@@ -7,8 +7,6 @@
  *                      OPA firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_OPA_H
 #define __CH32V00x_OPA_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_pwr.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_pwr.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_PWR_H
 #define __CH32V00x_PWR_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_rcc.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_rcc.h
@@ -6,8 +6,6 @@
  * Description        : This file provides all the RCC firmware functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_RCC_H
 #define __CH32V00x_RCC_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_spi.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_spi.h
@@ -7,8 +7,6 @@
  *                      SPI firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_SPI_H
 #define __CH32V00x_SPI_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_tim.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_tim.h
@@ -7,8 +7,6 @@
  *                      TIM firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_TIM_H
 #define __CH32V00x_TIM_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_usart.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_usart.h
@@ -7,8 +7,6 @@
  *                      USART firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_USART_H
 #define __CH32V00x_USART_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_wwdg.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Peripheral/inc/ch32v00x_wwdg.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_WWDG_H
 #define __CH32V00x_WWDG_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Startup/startup_ch32v00x.S
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/sdk/Startup/startup_ch32v00x.S
@@ -6,8 +6,6 @@
 ;* Description        : vector table for eclipse toolchain.
 ;*********************************************************************************
 ;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-;* Attention: This software (modified or not) and binary are used for 
-;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 ;*******************************************************************************/
 
 	.section  .init, "ax", @progbits

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/ch32v00x_conf.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/ch32v00x_it.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/system_ch32v00x.h
+++ b/Demo Application/Easy_PD_Sink/Easy_PD_Sink_pro/src/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/ADC_DMA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/ADC_DMA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/ADC_DMA/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/ADC_DMA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/ADC_DMA/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/ADC_DMA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/AnalogWatchdog/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/AnalogWatchdog/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/AnalogWatchdog/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/AnalogWatchdog/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/AnalogWatchdog/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/AnalogWatchdog/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/Auto_Injection/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/Auto_Injection/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/Auto_Injection/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/Auto_Injection/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/Auto_Injection/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/Auto_Injection/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/Discontinuous_mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/Discontinuous_mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/Discontinuous_mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/Discontinuous_mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/Discontinuous_mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/Discontinuous_mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/ExtLines_Trigger/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/ExtLines_Trigger/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/ExtLines_Trigger/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/ExtLines_Trigger/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/ExtLines_Trigger/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/ExtLines_Trigger/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/ADC/TIM_Trigger/User/ch32v00x_conf.h
+++ b/EVT/EXAM/ADC/TIM_Trigger/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/ADC/TIM_Trigger/User/ch32v00x_it.h
+++ b/EVT/EXAM/ADC/TIM_Trigger/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/ADC/TIM_Trigger/User/system_ch32v00x.h
+++ b/EVT/EXAM/ADC/TIM_Trigger/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/APPLICATION/SoftUART/User/SoftUART.h
+++ b/EVT/EXAM/APPLICATION/SoftUART/User/SoftUART.h
@@ -6,8 +6,6 @@
  * Description        : Simulate UART with software
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 
 #ifndef USER_SOFTUART_H_

--- a/EVT/EXAM/APPLICATION/SoftUART/User/ch32v00x_conf.h
+++ b/EVT/EXAM/APPLICATION/SoftUART/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/APPLICATION/SoftUART/User/ch32v00x_it.h
+++ b/EVT/EXAM/APPLICATION/SoftUART/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/APPLICATION/SoftUART/User/system_ch32v00x.h
+++ b/EVT/EXAM/APPLICATION/SoftUART/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/DMA/DMA_MEM2MEM/User/ch32v00x_conf.h
+++ b/EVT/EXAM/DMA/DMA_MEM2MEM/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/DMA/DMA_MEM2MEM/User/ch32v00x_it.h
+++ b/EVT/EXAM/DMA/DMA_MEM2MEM/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/DMA/DMA_MEM2MEM/User/system_ch32v00x.h
+++ b/EVT/EXAM/DMA/DMA_MEM2MEM/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/EXTI/EXTI0/User/ch32v00x_conf.h
+++ b/EVT/EXAM/EXTI/EXTI0/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/EXTI/EXTI0/User/ch32v00x_it.h
+++ b/EVT/EXAM/EXTI/EXTI0/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/EXTI/EXTI0/User/system_ch32v00x.h
+++ b/EVT/EXAM/EXTI/EXTI0/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/FLASH/BootAsUser/Startup/startup_ch32v00x.S
+++ b/EVT/EXAM/FLASH/BootAsUser/Startup/startup_ch32v00x.S
@@ -7,8 +7,6 @@
 ;*                       (BOOT flash as user flash)
 ;*********************************************************************************
 ;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-;* Attention: This software (modified or not) and binary are used for 
-;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 ;*******************************************************************************/
 
 	.section	.bxx,"ax",@progbits

--- a/EVT/EXAM/FLASH/BootAsUser/User/ch32v00x_conf.h
+++ b/EVT/EXAM/FLASH/BootAsUser/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/FLASH/BootAsUser/User/ch32v00x_it.h
+++ b/EVT/EXAM/FLASH/BootAsUser/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/FLASH/BootAsUser/User/system_ch32v00x.h
+++ b/EVT/EXAM/FLASH/BootAsUser/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/FLASH/FLASH_Program/User/ch32v00x_conf.h
+++ b/EVT/EXAM/FLASH/FLASH_Program/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/FLASH/FLASH_Program/User/ch32v00x_it.h
+++ b/EVT/EXAM/FLASH/FLASH_Program/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/FLASH/FLASH_Program/User/system_ch32v00x.h
+++ b/EVT/EXAM/FLASH/FLASH_Program/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/GPIO/GPIO_Toggle/User/ch32v00x_conf.h
+++ b/EVT/EXAM/GPIO/GPIO_Toggle/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/GPIO/GPIO_Toggle/User/ch32v00x_it.h
+++ b/EVT/EXAM/GPIO/GPIO_Toggle/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/GPIO/GPIO_Toggle/User/system_ch32v00x.h
+++ b/EVT/EXAM/GPIO/GPIO_Toggle/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/I2C/I2C_10bit_Mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/I2C/I2C_10bit_Mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/I2C/I2C_10bit_Mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/I2C/I2C_10bit_Mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/I2C/I2C_10bit_Mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/I2C/I2C_10bit_Mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/I2C/I2C_7bit_Mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/I2C/I2C_7bit_Mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/I2C/I2C_7bit_Mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/I2C/I2C_7bit_Mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/I2C/I2C_7bit_Mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/I2C/I2C_7bit_Mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/I2C/I2C_DMA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/I2C/I2C_DMA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/I2C/I2C_DMA/User/ch32v00x_it.h
+++ b/EVT/EXAM/I2C/I2C_DMA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/I2C/I2C_DMA/User/system_ch32v00x.h
+++ b/EVT/EXAM/I2C/I2C_DMA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/I2C/I2C_EEPROM/User/ch32v00x_conf.h
+++ b/EVT/EXAM/I2C/I2C_EEPROM/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/I2C/I2C_EEPROM/User/ch32v00x_it.h
+++ b/EVT/EXAM/I2C/I2C_EEPROM/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/I2C/I2C_EEPROM/User/system_ch32v00x.h
+++ b/EVT/EXAM/I2C/I2C_EEPROM/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/I2C/I2C_PEC/User/ch32v00x_conf.h
+++ b/EVT/EXAM/I2C/I2C_PEC/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/I2C/I2C_PEC/User/ch32v00x_it.h
+++ b/EVT/EXAM/I2C/I2C_PEC/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/I2C/I2C_PEC/User/system_ch32v00x.h
+++ b/EVT/EXAM/I2C/I2C_PEC/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/IAP/V00x_APP/User/ch32v00x_conf.h
+++ b/EVT/EXAM/IAP/V00x_APP/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/IAP/V00x_APP/User/ch32v00x_it.h
+++ b/EVT/EXAM/IAP/V00x_APP/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/IAP/V00x_APP/User/system_ch32v00x.h
+++ b/EVT/EXAM/IAP/V00x_APP/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/IWDG/IWDG/User/ch32v00x_conf.h
+++ b/EVT/EXAM/IWDG/IWDG/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/IWDG/IWDG/User/ch32v00x_it.h
+++ b/EVT/EXAM/IWDG/IWDG/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/IWDG/IWDG/User/system_ch32v00x.h
+++ b/EVT/EXAM/IWDG/IWDG/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/OPA/OPA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/OPA/OPA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/OPA/OPA/User/ch32v00x_it.h
+++ b/EVT/EXAM/OPA/OPA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/OPA/OPA/User/system_ch32v00x.h
+++ b/EVT/EXAM/OPA/OPA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/PWR/PVD_VoltageJudger/User/ch32v00x_conf.h
+++ b/EVT/EXAM/PWR/PVD_VoltageJudger/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/PWR/PVD_VoltageJudger/User/ch32v00x_it.h
+++ b/EVT/EXAM/PWR/PVD_VoltageJudger/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/PWR/PVD_VoltageJudger/User/system_ch32v00x.h
+++ b/EVT/EXAM/PWR/PVD_VoltageJudger/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/PWR/PVD_Wakeup/User/ch32v00x_conf.h
+++ b/EVT/EXAM/PWR/PVD_Wakeup/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/PWR/PVD_Wakeup/User/ch32v00x_it.h
+++ b/EVT/EXAM/PWR/PVD_Wakeup/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/PWR/PVD_Wakeup/User/system_ch32v00x.h
+++ b/EVT/EXAM/PWR/PVD_Wakeup/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/PWR/Sleep_Mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/PWR/Sleep_Mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/PWR/Sleep_Mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/PWR/Sleep_Mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/PWR/Sleep_Mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/PWR/Sleep_Mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/PWR/Standby_Mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/PWR/Standby_Mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/PWR/Standby_Mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/PWR/Standby_Mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/PWR/Standby_Mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/PWR/Standby_Mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/RCC/Get_CLK/User/ch32v00x_conf.h
+++ b/EVT/EXAM/RCC/Get_CLK/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/RCC/Get_CLK/User/ch32v00x_it.h
+++ b/EVT/EXAM/RCC/Get_CLK/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/RCC/Get_CLK/User/system_ch32v00x.h
+++ b/EVT/EXAM/RCC/Get_CLK/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/RCC/MCO/User/ch32v00x_conf.h
+++ b/EVT/EXAM/RCC/MCO/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/RCC/MCO/User/ch32v00x_it.h
+++ b/EVT/EXAM/RCC/MCO/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/RCC/MCO/User/system_ch32v00x.h
+++ b/EVT/EXAM/RCC/MCO/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SDI_Printf/SDI_Printf/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SDI_Printf/SDI_Printf/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SDI_Printf/SDI_Printf/User/ch32v00x_it.h
+++ b/EVT/EXAM/SDI_Printf/SDI_Printf/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SDI_Printf/SDI_Printf/User/system_ch32v00x.h
+++ b/EVT/EXAM/SDI_Printf/SDI_Printf/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SPI/1Lines_half-duplex/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SPI/1Lines_half-duplex/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SPI/1Lines_half-duplex/User/ch32v00x_it.h
+++ b/EVT/EXAM/SPI/1Lines_half-duplex/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SPI/1Lines_half-duplex/User/system_ch32v00x.h
+++ b/EVT/EXAM/SPI/1Lines_half-duplex/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SPI/2Lines_FullDuplex/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SPI/2Lines_FullDuplex/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SPI/2Lines_FullDuplex/User/ch32v00x_it.h
+++ b/EVT/EXAM/SPI/2Lines_FullDuplex/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SPI/2Lines_FullDuplex/User/system_ch32v00x.h
+++ b/EVT/EXAM/SPI/2Lines_FullDuplex/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SPI/FullDuplex_HardNSS/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SPI/FullDuplex_HardNSS/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SPI/FullDuplex_HardNSS/User/ch32v00x_it.h
+++ b/EVT/EXAM/SPI/FullDuplex_HardNSS/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SPI/FullDuplex_HardNSS/User/system_ch32v00x.h
+++ b/EVT/EXAM/SPI/FullDuplex_HardNSS/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SPI/SPI_CRC/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SPI/SPI_CRC/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SPI/SPI_CRC/User/ch32v00x_it.h
+++ b/EVT/EXAM/SPI/SPI_CRC/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SPI/SPI_CRC/User/system_ch32v00x.h
+++ b/EVT/EXAM/SPI/SPI_CRC/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SPI/SPI_DMA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SPI/SPI_DMA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SPI/SPI_DMA/User/ch32v00x_it.h
+++ b/EVT/EXAM/SPI/SPI_DMA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SPI/SPI_DMA/User/system_ch32v00x.h
+++ b/EVT/EXAM/SPI/SPI_DMA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/SRC/Core/core_riscv.h
+++ b/EVT/EXAM/SRC/Core/core_riscv.h
@@ -6,8 +6,6 @@
  * Description        : RISC-V V2 Core Peripheral Access Layer Header File for CH32V003
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CORE_RISCV_H__
 #define __CORE_RISCV_H__

--- a/EVT/EXAM/SRC/Debug/debug.h
+++ b/EVT/EXAM/SRC/Debug/debug.h
@@ -7,8 +7,6 @@
  *                      Printf , Delay functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __DEBUG_H
 #define __DEBUG_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer Header File.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_H
 #define __CH32V00x_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_adc.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_adc.h
@@ -7,8 +7,6 @@
  *                      ADC firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_ADC_H
 #define __CH32V00x_ADC_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_dbgmcu.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_dbgmcu.h
@@ -7,8 +7,6 @@
  *                      DBGMCU firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_DBGMCU_H
 #define __CH32V00x_DBGMCU_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_dma.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_dma.h
@@ -7,8 +7,6 @@
  *                      DMA firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_DMA_H
 #define __CH32V00x_DMA_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_exti.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_exti.h
@@ -7,8 +7,6 @@
  *                      EXTI firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_EXTI_H
 #define __CH32V00x_EXTI_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_flash.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_flash.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_FLASH_H
 #define __CH32V00x_FLASH_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_gpio.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_gpio.h
@@ -7,8 +7,6 @@
  *                      GPIO firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_GPIO_H
 #define __CH32V00x_GPIO_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_i2c.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_i2c.h
@@ -7,8 +7,6 @@
  *                      I2C firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_I2C_H
 #define __CH32V00x_I2C_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_iwdg.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_iwdg.h
@@ -7,8 +7,6 @@
  *                      IWDG firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_IWDG_H
 #define __CH32V00x_IWDG_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_misc.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_misc.h
@@ -7,8 +7,6 @@
  *                      miscellaneous firmware library functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/   
 #ifndef __CH32V00X_MISC_H
 #define __CH32V00X_MISC_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_opa.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_opa.h
@@ -7,8 +7,6 @@
  *                      OPA firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_OPA_H
 #define __CH32V00x_OPA_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_pwr.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_pwr.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_PWR_H
 #define __CH32V00x_PWR_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_rcc.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_rcc.h
@@ -6,8 +6,6 @@
  * Description        : This file provides all the RCC firmware functions.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_RCC_H
 #define __CH32V00x_RCC_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_spi.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_spi.h
@@ -7,8 +7,6 @@
  *                      SPI firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_SPI_H
 #define __CH32V00x_SPI_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_tim.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_tim.h
@@ -7,8 +7,6 @@
  *                      TIM firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_TIM_H
 #define __CH32V00x_TIM_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_usart.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_usart.h
@@ -7,8 +7,6 @@
  *                      USART firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_USART_H
 #define __CH32V00x_USART_H

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_wwdg.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32v00x_wwdg.h
@@ -7,8 +7,6 @@
  *                      firmware library.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __CH32V00x_WWDG_H
 #define __CH32V00x_WWDG_H

--- a/EVT/EXAM/SRC/Startup/startup_ch32v00x.S
+++ b/EVT/EXAM/SRC/Startup/startup_ch32v00x.S
@@ -6,8 +6,6 @@
 ;* Description        : vector table for eclipse toolchain.
 ;*********************************************************************************
 ;* Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-;* Attention: This software (modified or not) and binary are used for 
-;* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 ;*******************************************************************************/
 
 	.section  .init, "ax", @progbits

--- a/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/ch32v00x_conf.h
+++ b/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/ch32v00x_it.h
+++ b/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/system_ch32v00x.h
+++ b/EVT/EXAM/SYSTICK/SYSTICK_Interrupt/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
  *********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Clock_Select/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Clock_Select/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Clock_Select/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Clock_Select/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Clock_Select/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Clock_Select/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/ComplementaryOutput_DeadTime/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Encoder/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Encoder/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Encoder/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Encoder/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Encoder/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Encoder/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/ExtTrigger_Start_Two_Timer/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Input_Capture/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Input_Capture/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Input_Capture/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Input_Capture/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Input_Capture/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Input_Capture/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/One_Pulse/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/One_Pulse/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/One_Pulse/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/One_Pulse/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/One_Pulse/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/One_Pulse/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Output_Compare_Mode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Output_Compare_Mode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Output_Compare_Mode/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Output_Compare_Mode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Output_Compare_Mode/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Output_Compare_Mode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/PWM_Output/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/PWM_Output/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/PWM_Output/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/PWM_Output/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/PWM_Output/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/PWM_Output/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Synchro_ExtTrigger/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Synchro_ExtTrigger/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Synchro_ExtTrigger/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Synchro_ExtTrigger/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Synchro_ExtTrigger/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Synchro_ExtTrigger/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/Synchro_Timer/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/Synchro_Timer/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/Synchro_Timer/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/Synchro_Timer/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/Synchro_Timer/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/Synchro_Timer/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/TIM/TIM_DMA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/TIM/TIM_DMA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/TIM/TIM_DMA/User/ch32v00x_it.h
+++ b/EVT/EXAM/TIM/TIM_DMA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/TIM/TIM_DMA/User/system_ch32v00x.h
+++ b/EVT/EXAM/TIM/TIM_DMA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_DMA/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_DMA/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_DMA/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_DMA/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_DMA/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_DMA/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_HalfDuplex/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_HalfDuplex/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_HalfDuplex/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_HalfDuplex/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_HalfDuplex/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_HalfDuplex/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_HardwareFlowControl/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_HardwareFlowControl/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_HardwareFlowControl/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_HardwareFlowControl/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_HardwareFlowControl/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_HardwareFlowControl/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_Interrupt/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_Interrupt/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_Interrupt/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_Interrupt/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_Interrupt/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_Interrupt/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_MultiProcessorCommunication/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_Polling/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_Polling/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_Polling/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_Polling/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_Polling/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_Polling/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_Printf/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_Printf/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_Printf/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_Printf/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_Printf/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_Printf/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART/USART_SynchronousMode/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART/USART_SynchronousMode/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART/USART_SynchronousMode/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART/USART_SynchronousMode/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART/USART_SynchronousMode/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART/USART_SynchronousMode/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART_IAP/CH32V003_APP/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_APP/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART_IAP/CH32V003_APP/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_APP/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART_IAP/CH32V003_APP/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_APP/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/USART_IAP/CH32V003_IAP/User/ch32v00x_conf.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_IAP/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/USART_IAP/CH32V003_IAP/User/ch32v00x_it.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_IAP/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/USART_IAP/CH32V003_IAP/User/flash.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_IAP/User/flash.h
@@ -6,8 +6,6 @@
 * Description        :
 *******************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __FLASH_H
 #define __FLASH_H

--- a/EVT/EXAM/USART_IAP/CH32V003_IAP/User/iap.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_IAP/User/iap.h
@@ -6,8 +6,6 @@
  * Description        : IAP
  *******************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
- * Attention: This software (modified or not) and binary are used for 
- * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 #ifndef __IAP_H
 #define __IAP_H

--- a/EVT/EXAM/USART_IAP/CH32V003_IAP/User/system_ch32v00x.h
+++ b/EVT/EXAM/USART_IAP/CH32V003_IAP/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/EVT/EXAM/WWDG/WWDG/User/ch32v00x_conf.h
+++ b/EVT/EXAM/WWDG/WWDG/User/ch32v00x_conf.h
@@ -6,8 +6,6 @@
  * Description        : Library configuration file.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_CONF_H
 #define __CH32V00x_CONF_H

--- a/EVT/EXAM/WWDG/WWDG/User/ch32v00x_it.h
+++ b/EVT/EXAM/WWDG/WWDG/User/ch32v00x_it.h
@@ -6,8 +6,6 @@
  * Description        : This file contains the headers of the interrupt handlers.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __CH32V00x_IT_H
 #define __CH32V00x_IT_H

--- a/EVT/EXAM/WWDG/WWDG/User/system_ch32v00x.h
+++ b/EVT/EXAM/WWDG/WWDG/User/system_ch32v00x.h
@@ -6,8 +6,6 @@
  * Description        : CH32V00x Device Peripheral Access Layer System Header File.
 *********************************************************************************
 * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
-* Attention: This software (modified or not) and binary are used for 
-* microcontroller manufactured by Nanjing Qinheng Microelectronics.
 *******************************************************************************/
 #ifndef __SYSTEM_CH32V00x_H
 #define __SYSTEM_CH32V00x_H

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,4 @@
+The header files in this repository are dual-licensed under MIT License and
+Apache-2.0 License.
+
+Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.


### PR DESCRIPTION
Hi,

We are adding support for CH32 RISC-V MCUs in Zephyr via https://github.com/zephyrproject-rtos/zephyr/pull/73761.

The following licensing text in this repository is NOT compatible with Zephyr.

```
Attention: This software (modified or not) and binary are used for 
microcontroller manufactured by Nanjing Qinheng Microelectronics.
```

This PR removes this restrictive licensing condition and explicitly licenses the header files in this repository under a dual-license (MIT License and Apache-2.0 License). Please note that many files in this repository are already licensed under Apache-2.0 License.

CC  @openwch @fabiobaltieri @nzmichaelh @AlexanderMandera @cnlohr.