### PR TITLE
Fix SDI printf not working

### DIFF
--- a/EVT/EXAM/SRC/Debug/debug.c
+++ b/EVT/EXAM/SRC/Debug/debug.c
@@ -337,7 +337,7 @@ int _write(int fd, char *buf, int size)
 
 
 #endif
-    return writeSize;
+    return size;
 }
 
 /*********************************************************************


### PR DESCRIPTION
The _write function should return the number of bytes written. (see https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/write?view=msvc-170#return-value )
Otherwise, the printf implementation doesn't work (either keeps repeating or HardFaults)